### PR TITLE
Fix mispelled signals and missing pins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,6 @@ xrun-ci: xrun-asm-tests xrun-amo-tests xrun-mul-tests xrun-fp-tests xrun-benchma
 # verilator-specific
 verilate_command := $(verilator) --no-timing verilator_config.vlt                                                \
                     -f core/Flist.cva6                                                                           \
-                    core/cva6_rvfi.sv                                                                            \
                     $(filter-out %.vhd, $(ariane_pkg))                                                           \
                     $(filter-out core/fpu_wrap.sv, $(filter-out %.vhd, $(filter-out %_config_pkg.sv, $(src))))   \
                     +define+$(defines)$(if $(TRACE_FAST),+VM_TRACE)$(if $(TRACE_COMPACT),+VM_TRACE+VM_TRACE_FST) \

--- a/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
+++ b/core/cache_subsystem/cva6_hpdcache_if_adapter.sv
@@ -184,7 +184,6 @@ module cva6_hpdcache_if_adapter
 
       //    Response forwarding ypb channel R
 
-      assign ypb_load_rsp_o.gnt = '0;  //unused
       assign ypb_load_rsp_o.rvalid = hpdcache_rsp_valid_i;
       assign ypb_load_rsp_o.rid = hpdcache_rsp_i.tid;
       assign ypb_load_rsp_o.err = '0;

--- a/core/csr_regfile.sv
+++ b/core/csr_regfile.sv
@@ -1811,8 +1811,8 @@ module csr_regfile
     // mark the floating point extension register as dirty
     if (CVA6Cfg.FpPresent && (dirty_fp_state_csr || dirty_fp_state_i)) begin
       mstatus_d.fs = riscv::Dirty;
-      if (CVA6Cfg.RVH) begin
-        vsstatus_d.fs = v_q & riscv::Dirty;
+      if (CVA6Cfg.RVH && v_q) begin
+        vsstatus_d.fs = riscv::Dirty;
       end
     end
     // mark the vector extension register as dirty

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -202,7 +202,7 @@ module cva6
   );
 
 
-  if (CVA6Cfg.PipelineOnly) begin : gen_cache_subsystem
+  if (CVA6Cfg.PipelineOnly) begin : gen_obi_adapter
 
     // -------------------
     // OBI Adapter
@@ -262,7 +262,7 @@ module cva6
         .noc_resp_i(noc_resp_i)
     );
 
-  end else begin : gen_obi_adapter
+  end else begin : gen_cache_subsystem
 
     // -------------------
     // Cache Subsystem

--- a/core/cva6.sv
+++ b/core/cva6.sv
@@ -89,7 +89,7 @@ module cva6
   localparam type ypb_zcmt_rsp_t = `YPB_RSP_T(CVA6Cfg, CVA6Cfg.XLEN);
 
 
-  logic icache_en;
+  logic icache_enable;
   logic icache_flush;
   logic icache_miss;
 

--- a/core/cva6_mmu/cva6_ptw.sv
+++ b/core/cva6_mmu/cva6_ptw.sv
@@ -381,9 +381,9 @@ module cva6_ptw
 
       WAIT_GRANT: begin
         // send a request out
-        obi_mmu_ptw_req_o.vreq = 1'b1;
+        ypb_mmu_ptw_req_o.vreq = 1'b1;
         // wait for the WAIT_GRANT
-        if (obi_mmu_ptw_rsp_i.vgnt) begin
+        if (ypb_mmu_ptw_rsp_i.vgnt) begin
           // send the tag valid signal one cycle later
           tag_valid_n = 1'b1;
           state_d     = PTE_LOOKUP;
@@ -603,7 +603,7 @@ module cva6_ptw
       // 1. in the PTE Lookup check whether we still need to wait for an rvalid
       // 2. waiting for a grant, if so: wait for it
       // if not, go back to idle
-      if (((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q) || ((state_q == WAIT_GRANT) && obi_mmu_ptw_rsp_i.rvalid))
+      if (((state_q inside {PTE_LOOKUP, WAIT_RVALID}) && !data_rvalid_q) || ((state_q == WAIT_GRANT) && ypb_mmu_ptw_rsp_i.rvalid))
         state_d = WAIT_RVALID;
       else state_d = LATENCY;
     end
@@ -638,8 +638,8 @@ module cva6_ptw
       tlb_update_asid_q <= tlb_update_asid_n;
       vaddr_q           <= vaddr_n;
       global_mapping_q  <= global_mapping_n;
-      data_rdata_q      <= obi_mmu_ptw_rsp_i.rdata;
-      data_rvalid_q     <= obi_mmu_ptw_rsp_i.rvalid;
+      data_rdata_q      <= ypb_mmu_ptw_rsp_i.rdata;
+      data_rvalid_q     <= ypb_mmu_ptw_rsp_i.rvalid;
 
       if (CVA6Cfg.RVH) begin
         gpaddr_q          <= gpaddr_n;

--- a/core/cva6_pipeline.sv
+++ b/core/cva6_pipeline.sv
@@ -12,8 +12,7 @@
 // Date: 19.03.2017
 // Description: CVA6 Core module
 
-`include "obi/typedef.svh"
-`include "obi/assign.svh"
+`include "ypb_types.svh"
 `include "rvfi_types.svh"
 `include "cvxif_types.svh"
 
@@ -1102,7 +1101,6 @@ module cva6_pipeline
         .ypb_amo_req_t     (ypb_amo_req_t),
         .ypb_load_req_t    (ypb_load_req_t),
         .ypb_mmu_ptw_req_t (ypb_mmu_ptw_req_t),
-        .ypb_zcmt_req_t    (ypb_zcmt_req_t),
         .NumMissPorts      (1  /*FIXME*/)         //WT cache only ??
     ) perf_counters_i (
         .clk_i         (clk_i),
@@ -1133,7 +1131,6 @@ module cva6_pipeline
         .ypb_amo_req_i    (ypb_amo_req_o),
         .ypb_load_req_i   (ypb_load_req_o),
         .ypb_mmu_ptw_req_i(ypb_mmu_ptw_req_o),
-        .ypb_zcmt_req_i   (ypb_zcmt_req_o),
         .miss_vld_bits_i  ('0  /*FIXME*/),          //WT cache only ??
         .i_tlb_flush_i    (flush_tlb_ctrl_ex),
         .stall_issue_i    (stall_issue),

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -457,13 +457,12 @@ module frontend
   ypb_a_state_e ypb_a_state_d, ypb_a_state_q;
 
 
-  logic stall_ypb, stall_translation;
+  logic stall_ni, stall_ypb, stall_translation;
   logic data_req, data_rvalid;
 
   assign stall_ni = spec_req_non_idempot;
   assign stall_ypb = (ypb_a_state_q == REGISTRED);  //&& !ypb_load_rsp_i.pgnt;
   assign stall_translation = CVA6Cfg.MmuPresent ? areq_o.fetch_req && (!arsp_i.fetch_valid) : 1'b0;
-  assign stall_instr_queue = instr_queue_ready;
 
   assign ex_s1 = (CVA6Cfg.MmuPresent && arsp_i.fetch_exception.valid);
 

--- a/core/frontend/frontend.sv
+++ b/core/frontend/frontend.sv
@@ -540,6 +540,7 @@ module frontend
     ypb_a_state_q == TRANSPARENT ? paddr[CVA6Cfg.PLEN-1:CVA6Cfg.FETCH_ALIGN_BITS] : paddr_q[CVA6Cfg.PLEN-1:CVA6Cfg.FETCH_ALIGN_BITS],
     {CVA6Cfg.FETCH_ALIGN_BITS{1'b0}}
   };
+  assign ypb_fetch_req_o.size = CVA6Cfg.FETCH_ALIGN_BITS;
   assign ypb_fetch_req_o.we = '0;
   assign ypb_fetch_req_o.be = '1;
   assign ypb_fetch_req_o.wdata = '0;

--- a/core/include/build_config_pkg.sv
+++ b/core/include/build_config_pkg.sv
@@ -158,7 +158,7 @@ package build_config_pkg;
     cfg.WtDcacheWbufDepth = CVA6Cfg.WtDcacheWbufDepth;
     cfg.FETCH_USER_WIDTH = CVA6Cfg.FetchUserWidth;
     cfg.FETCH_USER_EN = CVA6Cfg.FetchUserEn;
-    cfg.AXI_USER_EN = CVA6Cfg.DataUserEn | CVA6Cfg.FetchUserEn;
+    cfg.AXI_USER_EN = (CVA6Cfg.DataUserEn > 0) || (CVA6Cfg.FetchUserEn > 0);
 
     cfg.FETCH_WIDTH = unsigned'((CVA6Cfg.SuperscalarEn && !CVA6Cfg.PipelineOnly) ? 64 : 32);
     cfg.FETCH_BE_WIDTH = cfg.FETCH_WIDTH / 8;

--- a/core/perf_counters.sv
+++ b/core/perf_counters.sv
@@ -19,13 +19,11 @@ module perf_counters
     parameter config_pkg::cva6_cfg_t CVA6Cfg = config_pkg::cva6_cfg_empty,
     parameter type bp_resolve_t = logic,
     parameter type exception_t = logic,
-    parameter type fetch_req_t = logic,
-    parameter type obi_fetch_req_t = logic,
-    parameter type obi_store_req_t = logic,
-    parameter type obi_amo_req_t = logic,
-    parameter type load_req_t = logic,
-    parameter type obi_load_req_t = logic,
-    parameter type obi_mmu_ptw_req_t = logic,
+    parameter type ypb_fetch_req_t = logic,
+    parameter type ypb_store_req_t = logic,
+    parameter type ypb_amo_req_t = logic,
+    parameter type ypb_load_req_t = logic,
+    parameter type ypb_mmu_ptw_req_t = logic,
     parameter type scoreboard_entry_t = logic,
     parameter int unsigned NumMissPorts = 3  // number of miss ports
 ) (
@@ -58,13 +56,11 @@ module perf_counters
     // for newly added events
     input exception_t branch_exceptions_i,  //Branch exceptions->execute unit-> branch_exception_o
 
-    input fetch_req_t       fetch_req_i,
-    input obi_fetch_req_t   fetch_obi_req_i,
-    input obi_store_req_t   obi_store_req_i,
-    input obi_amo_req_t     obi_amo_req_i,
-    input load_req_t        load_req_i,
-    input obi_load_req_t    obi_load_req_i,
-    input obi_mmu_ptw_req_t obi_mmu_ptw_req_i,
+    input ypb_fetch_req_t   ypb_fetch_req_i,
+    input ypb_store_req_t   ypb_store_req_i,
+    input ypb_amo_req_t     ypb_amo_req_i,
+    input ypb_load_req_t    ypb_load_req_i,
+    input ypb_mmu_ptw_req_t ypb_mmu_ptw_req_i,
 
     input  logic [NumMissPorts-1:0][CVA6Cfg.DCACHE_SET_ASSOC-1:0]miss_vld_bits_i,  //For Cache eviction (3ports-LOAD,STORE,PTW)
     input logic i_tlb_flush_i,
@@ -134,9 +130,9 @@ module perf_counters
         5'b01101: events[i] = |return_event;  //Return
         5'b01110: events[i] = sb_full_i;  //MSB Full
         5'b01111: events[i] = if_empty_i;  //Instruction fetch Empty
-        5'b10000: events[i] = fetch_obi_req_i.req;  //L1 I-Cache accesses
+        5'b10000: events[i] = ypb_fetch_req_i.req;  //L1 I-Cache accesses
         5'b10001:
-        events[i] = obi_mmu_ptw_req_i.data_req || obi_load_req_i.req || obi_store_req_i.req || obi_amo_req_i.req;//L1 D-Cache accesses
+        events[i] = ypb_mmu_ptw_req_i.data_req || ypb_load_req_i.req || ypb_store_req_i.req || ypb_amo_req_i.req;//L1 D-Cache accesses
         5'b10010: begin
           events[i] = 0;
           if (l1_dcache_miss_i) begin

--- a/corev_apu/src/ariane.sv
+++ b/corev_apu/src/ariane.sv
@@ -69,7 +69,9 @@ module ariane import ariane_pkg::*; #(
 
   cva6 #(
     .CVA6Cfg              ( CVA6Cfg                   ),
-    .rvfi_probes_t        ( rvfi_probes_t             )
+    .rvfi_probes_t        ( rvfi_probes_t             ),
+    .noc_req_t            ( noc_req_t                 ),
+    .noc_resp_t           ( noc_resp_t                )
   ) i_cva6 (
     .clk_i                ( clk_i                     ),
     .rst_ni               ( rst_ni                    ),

--- a/corev_apu/tb/ariane_testharness.sv
+++ b/corev_apu/tb/ariane_testharness.sv
@@ -674,8 +674,6 @@ module ariane_testharness #(
       .CVA6Cfg   (CVA6Cfg),
       .rvfi_instr_t(rvfi_instr_t),
       .rvfi_csr_t(rvfi_csr_t),
-      .rvfi_probes_instr_t(rvfi_probes_instr_t),
-      .rvfi_probes_csr_t(rvfi_probes_csr_t),
       .rvfi_probes_t(rvfi_probes_t)
   ) i_cva6_rvfi (
       .clk_i     (clk_i),


### PR DESCRIPTION
When compiling with Verilator, it alerts about different errors. Some of these are fixed in this PR.